### PR TITLE
Revert "Fix include formatting for unordered_map"

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <unordered_map> 
+#include <unordered_map>
 #include <optional>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Reverts supervoidcoder/win-witr#37