### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build Check
 on: [pull_request, push]
-
+permissions:
+  contents: read
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/supervoidcoder/win-witr/security/code-scanning/7](https://github.com/supervoidcoder/win-witr/security/code-scanning/7)

In general, to fix this type of issue you add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or within each job (to scope permissions per job). The block should grant only the privileges required by that workflow/job, typically starting with `contents: read` when the job only needs to check out code.

For this specific workflow, the `build-windows` job only checks out the repository and runs compilation/tests. It does not create or modify GitHub resources, so it only needs read access to the repository contents. The best fix is to add a `permissions` block at the workflow root level (just under `name:` and `on:`) with `contents: read`. This will apply to all jobs in the workflow (currently only `build-windows`) and will not change existing behavior, because read access is already required by `actions/checkout`. No additional imports, tools, or methods are needed—this is a pure YAML configuration change.

Concretely: edit `.github/workflows/build.yml` and insert:

```yaml
permissions:
  contents: read
```

between the `on:` line and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to enhance security permissions settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->